### PR TITLE
fix: 在分组因子函数中添加随机噪声以确保唯一分箱边界

### DIFF
--- a/panda_factor/panda_factor/analysis/factor_func.py
+++ b/panda_factor/panda_factor/analysis/factor_func.py
@@ -603,7 +603,10 @@ def grouping_factor(df: pd.DataFrame, factor_name: str, group_cnt: int = 10, log
         
         # Use qcut for grouping and ensure the number of groups is correct
         try:
-            new_group[f'{factor_name}_group'] = pd.qcut(group[factor_name].dropna(), q=group_cnt, labels=range(1, group_cnt+1))
+            # Add a small random noise to ensure unique bin edges
+            noise = np.random.normal(0, 1e-10, size=group[factor_name].dropna().shape)
+            noisy_values = group[factor_name].dropna().values + noise
+            new_group[f'{factor_name}_group'] = pd.qcut(noisy_values, q=group_cnt, labels=range(1, group_cnt+1))
         except ValueError as e:
             if logger:
                 logger.error(f"{factor_name},{date},grouping failed: {str(e)}")
@@ -612,16 +615,16 @@ def grouping_factor(df: pd.DataFrame, factor_name: str, group_cnt: int = 10, log
             continue
 
         grouped_dfs.append(new_group)
-    
+        
     # Merge all processed groups
     if grouped_dfs:
         df_cuted = pd.concat(grouped_dfs)
     else:
         df_cuted = pd.DataFrame()  # If there's no valid data, return an empty DataFrame
-    
+        
     # Convert benchmark index returns to DataFrame
     df_benchmark = pd.DataFrame(benchmark_pct).T
-    
+
     return df_cuted, df_benchmark
 
 def change_code(s):


### PR DESCRIPTION
在`grouping_factor`函数中，添加了一个小的随机噪声以避免`pd.qcut`因重复值导致的错误。这确保了分箱边界的唯一性，从而避免了分组失败的情况。
由于 `1e-10` 的噪声足够小，不会影响因子本身的统计特性，但能确保分组过程的稳定性。